### PR TITLE
Fix dialog box freezing issues

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,6 +78,7 @@ set(libdshowcapture_SOURCES
 	source/dshow-formats.cpp
 	source/dshow-media-type.cpp
 	source/dshow-encoded-device.cpp
+	source/dshow-dialogbox.cpp
 	source/log.cpp)
 
 set(libdshowcapture_HEADERS
@@ -93,6 +94,7 @@ set(libdshowcapture_HEADERS
 	source/dshow-enum.hpp
 	source/dshow-formats.hpp
 	source/dshow-media-type.hpp
+	source/dshow-dialogbox.hpp
 	source/log.hpp)
 
 add_library(libdshowcapture

--- a/dshowcapture.hpp
+++ b/dshowcapture.hpp
@@ -49,6 +49,7 @@ struct HDevice;
 struct HVideoEncoder;
 struct VideoConfig;
 struct AudioConfig;
+struct DeviceDialogBox;
 
 typedef std::function<void(const VideoConfig &config, unsigned char *data,
 			   size_t size, long long startTime, long long stopTime)>
@@ -202,6 +203,9 @@ struct AudioConfig : Config {
 
 class DSHOWCAPTURE_EXPORT Device {
 	HDevice *context;
+	DeviceDialogBox *videoDialog;
+	DeviceDialogBox *crossbarDialog;
+	DeviceDialogBox *audioDialog;
 
 public:
 	Device(InitGraph initialize = InitGraph::False);
@@ -238,6 +242,7 @@ public:
 		 * @param  type  The dialog type
 		 */
 	void OpenDialog(void *hwnd, DialogType type) const;
+	void CloseDialog();
 
 	static bool EnumVideoDevices(std::vector<VideoDevice> &devices);
 	static bool EnumAudioDevices(std::vector<AudioDevice> &devices);

--- a/source/dshow-dialogbox.cpp
+++ b/source/dshow-dialogbox.cpp
@@ -1,0 +1,50 @@
+#include "dshow-dialogbox.hpp"
+#include "log.hpp"
+
+namespace DShow {
+    DeviceDialogBox::DeviceDialogBox() :
+        deviceFilter(nullptr),
+        threadId(0),
+        threadHandle(nullptr),
+        isOpen(false)
+    {
+    }
+
+    void DeviceDialogBox::Open(IUnknown* filter) {
+        if (!isOpen) {
+            deviceFilter = filter;
+            threadHandle = CreateThread(nullptr, 0, CallCreate, (void*) this, 0, &threadId);
+
+            if (threadHandle == nullptr) {
+                Warning(L"Could not create thread for filter dialog box");
+            }
+        }
+    }
+
+    void DeviceDialogBox::Close() {
+        if (isOpen) {
+            PostThreadMessage(threadId, WM_QUIT, 0, 0);
+            CloseHandle(threadHandle);
+            isOpen = false;
+        }
+    }
+
+    DWORD DeviceDialogBox::Create() {
+        ComQIPtr<ISpecifyPropertyPages> pages(deviceFilter);
+        CAUUID cauuid;
+
+        if (pages != nullptr) {
+            if (SUCCEEDED(pages->GetPages(&cauuid)) && cauuid.cElems) {
+                isOpen = true;
+                OleCreatePropertyFrame(nullptr, 0, 0, nullptr, 1,
+                                       (LPUNKNOWN *)&deviceFilter,
+                                       cauuid.cElems, cauuid.pElems, 0,
+                                       0, nullptr);
+                CoTaskMemFree(cauuid.pElems);
+            }
+        }
+
+        isOpen = false;
+        return 0;
+    }
+}

--- a/source/dshow-dialogbox.cpp
+++ b/source/dshow-dialogbox.cpp
@@ -11,7 +11,7 @@ namespace DShow {
     }
 
     void DeviceDialogBox::Open(IUnknown* filter) {
-        if (!isOpen) {
+        if (!isOpen || WaitForSingleObject(threadHandle, 0) == WAIT_OBJECT_0) {
             deviceFilter = filter;
             threadHandle = CreateThread(nullptr, 0, CallCreate, (void*) this, 0, &threadId);
 
@@ -44,7 +44,6 @@ namespace DShow {
             }
         }
 
-        isOpen = false;
         return 0;
     }
 }

--- a/source/dshow-dialogbox.hpp
+++ b/source/dshow-dialogbox.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "../dshowcapture.hpp"
+#include "dshow-base.hpp"
+
+namespace DShow {
+    struct DeviceDialogBox {
+        DeviceDialogBox();
+        ~DeviceDialogBox() = default;
+
+        void Open(IUnknown* filter);
+        void Close();
+        DWORD Create();
+
+        static DWORD WINAPI CallCreate(void* param) {
+            DeviceDialogBox* obj = (DeviceDialogBox*) param;
+            return obj->Create();
+        }
+
+        IUnknown* deviceFilter;
+        DWORD threadId;
+        HANDLE threadHandle;
+        bool isOpen;
+    };
+};


### PR DESCRIPTION
Fixes two issues with dialog boxes:
* Source settings only being applied after the dialog box is closed
* Application stuck on a frozen state if there was a dialog box open when closing the application