### PR TITLE
Wrapped deviceFilter by ComPtr to keep it for the spawned thread

### DIFF
--- a/source/dshow-dialogbox.hpp
+++ b/source/dshow-dialogbox.hpp
@@ -17,7 +17,7 @@ namespace DShow {
             return obj->Create();
         }
 
-        IUnknown* deviceFilter;
+        ComPtr<IUnknown> deviceFilter;
         DWORD threadId;
         HANDLE threadHandle;
         bool isOpen;


### PR DESCRIPTION
### Description
Wrapped **deviceFilter** by ComPtr to be sure it is not destroyed from outside by the time when the thread starts execution.

### Motivation and Context
Probably, the issue is connected to the **Deactivate when not showing** option. The logs and crash dumps look like below.

**Logs** (the thread starts later than the deactivation)
- `"... 01:32.978.277 ... DShowLoop process action 5 for C6DEB510\n"` <- **5** means ConfigVideo which shows a configuration dialog via an additional thread which depends on the **deviceFilter**.
- `"... 01:32.978.363 ... DShowLoop process action 3 for C6DEB510\n"` <- **3** means Deactivate which releases the **deviceFilter**.

**Call Stack** (`ComQIPtr` calls `QueryInterface` method of an object which does not exist anymore)
>  000002a2ece46910() Unknown
> [Inline Frame] win-dshow.dll!ComQIPtr<ISpecifyPropertyPages>::{ctor}(IUnknown * unk) Line 147	C++
> [Inline Frame] win-dshow.dll!DShow::DeviceDialogBox::Create() Line 33	C++
> win-dshow.dll!DShow::DeviceDialogBox::CallCreate(void * param) Line 17	C++

### How Has This Been Tested?
I reproduced the issue with a hardcoded delay in the beginning of `DeviceDialogBox::Create()`. You can try to reproduce the issue with the regular Streamlabs Desktop if you feel lucky. The steps are:
1. Open a Video Capture Device properties
2. Click Configure Video
3. Click Deactivate

The issue is reproduced without the fix. The issue is not reproduced with the fix.

### Types of changes
- Bug fix (non-breaking change which fixes an issue)

