### PR TITLE
Added synchronization to DeviceDialogBox

### DIFF
--- a/source/dshow-dialogbox.cpp
+++ b/source/dshow-dialogbox.cpp
@@ -3,40 +3,91 @@
 
 namespace DShow {
     DeviceDialogBox::DeviceDialogBox() :
-        threadId(0),
-        threadHandle(nullptr),
-        isOpen(false)
+        threadHandle(nullptr)
     {
     }
 
-    void DeviceDialogBox::Open(IUnknown* filter) {
-        if (!isOpen || WaitForSingleObject(threadHandle, 0) == WAIT_OBJECT_0) {
-            deviceFilter = filter;
-            threadHandle = CreateThread(nullptr, 0, CallCreate, (void*) this, 0, &threadId);
+    DeviceDialogBox::~DeviceDialogBox()
+    {
+        Close();
+    }
 
-            if (threadHandle == nullptr) {
-                deviceFilter.Clear();
-                Warning(L"Could not create thread for filter dialog box");
-            }
+    void DeviceDialogBox::Open(IUnknown* filter) {
+        std::lock_guard<std::mutex> lock(mutex);
+
+        // Cleaning up a previously finished dialog thread, if any
+        if (threadHandle &&
+            WaitForSingleObject(threadHandle, 0) == WAIT_OBJECT_0) {
+            CloseHandle(threadHandle);
+            threadHandle = nullptr;
+        }
+
+        if (threadHandle) {
+            return;
+        }
+
+        deviceFilter = filter;
+        threadHandle = CreateThread(nullptr, 0, CallCreate, (void*) this, 0, nullptr);
+
+        if (threadHandle == nullptr) {
+            deviceFilter.Clear();
+            Warning(L"Could not create thread for filter dialog box");
         }
     }
 
     void DeviceDialogBox::Close() {
-        if (isOpen) {
-            PostThreadMessage(threadId, WM_QUIT, 0, 0);
-            CloseHandle(threadHandle);
-            isOpen = false;
+        HANDLE handle = nullptr;
+        DWORD tid = 0;
+
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (!threadHandle) {
+                deviceFilter.Clear();
+                return;
+            }
+
+            handle = threadHandle;
+            tid = GetThreadId(handle);
+            if (!tid) {
+                // Note: it is not a fatal error overall, and, if threadHandle was valid, it will not fail,
+                // so no early return here
+                DWORD err = GetLastError();
+                Warning(L"Could not get thread id for filter dialog box (error %lu)", err);
+            }
         }
+
+        if (tid) {
+            PostThreadMessage(tid, WM_QUIT, 0, 0);
+        }
+
+        WaitForSingleObject(handle, INFINITE);
+
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            if (threadHandle == handle) {
+                threadHandle = nullptr;
+                deviceFilter.Clear();
+            }
+        }
+
+        // Always close the handle we waited on, even if a newer thread started
+        // while waiting, to avoid leaking the old handle.
+        CloseHandle(handle);
     }
 
     DWORD DeviceDialogBox::Create() {
-        ComQIPtr<ISpecifyPropertyPages> pages(deviceFilter.Get());
+        ComPtr<IUnknown> filter;
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            filter = deviceFilter;
+        }
+
+        ComQIPtr<ISpecifyPropertyPages> pages(filter.Get());
         CAUUID cauuid;
 
         if (pages != nullptr) {
             if (SUCCEEDED(pages->GetPages(&cauuid)) && cauuid.cElems) {
-                isOpen = true;
-                IUnknown* objects[] = {deviceFilter.Get()};
+                IUnknown* objects[] = {filter.Get()};
                 OleCreatePropertyFrame(nullptr, 0, 0, nullptr, 1,
                                        objects,
                                        cauuid.cElems, cauuid.pElems, 0,
@@ -45,7 +96,10 @@ namespace DShow {
             }
             pages.Clear();
         }
-        deviceFilter.Clear();
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            deviceFilter.Clear();
+        }
 
         return 0;
     }

--- a/source/dshow-dialogbox.hpp
+++ b/source/dshow-dialogbox.hpp
@@ -3,10 +3,12 @@
 #include "../dshowcapture.hpp"
 #include "dshow-base.hpp"
 
+#include <mutex>
+
 namespace DShow {
     struct DeviceDialogBox {
         DeviceDialogBox();
-        ~DeviceDialogBox() = default;
+        ~DeviceDialogBox();
 
         void Open(IUnknown* filter);
         void Close();
@@ -17,9 +19,8 @@ namespace DShow {
             return obj->Create();
         }
 
+        std::mutex mutex;
         ComPtr<IUnknown> deviceFilter;
-        DWORD threadId;
         HANDLE threadHandle;
-        bool isOpen;
     };
 };


### PR DESCRIPTION
### Description
This change removes race conditions between Open()/Create(), avoids use-after-free on dialog thread teardown, and closes any completed thread handles deterministically.

This fixes a crash with the following stack (and potentially others):
```
mfksproxy	+0x1e823	CollectAllSets
mfksproxy	+0x0ca88	CMFProxyFilter::GetPages
win-dshow	+0x16f64	DShow::DeviceDialogBox::Create (dshow-dialogbox.cpp:37)
win-dshow	+0x16f64	DShow::DeviceDialogBox::CallCreate (dshow-dialogbox.hpp:17)
KERNEL32.DLL+0x2e8d6	BaseThreadInitThunk
ntdll		+0x8c53b	RtlUserThreadStart
```

Summary of changes:
- Serialized dialog creation with a mutex and eliminated redundant isOpen/threadRunning flags; threadHandle is the single state variable now.
- Ensured thread shutdown is joined in Close() and the dialog thread is safely reaped before destruction.
- Switched to GetThreadId(threadHandle) for PostThreadMessage, adding warning logs if retrieval fails.
- Prevented handle leaks by always closing the waited-on thread handle, even if a newer thread started while waiting.
- Improved  filter pointer usage by copying deviceFilter to a local ComPtr in the dialog thread.


### How does this crash happen?
> Note: all line references are given in the code before my changes.

1) The user triggers “Configure Video” twice quickly. Each click calls VideoConfigClicked, which just queues an action. `win-dshow.cpp:1589` and `win-dshow.cpp:1593`
2) The DShow thread processes the first action and calls DeviceDialogBox::Open(). isOpen is still false, so it assigns deviceFilter and starts a dialog thread. `dshow-dialogbox.cpp:12` and `dshow-dialogbox.cpp:15`.
3) Before the first dialog thread reaches Create() and sets isOpen, the DShow thread processes the second queued action and calls Open() again. Because isOpen is still false (it only flips to true inside Create()), this second call overwrites deviceFilter with a new COM pointer and spawns a second dialog thread. `dshow-dialogbox.cpp:13-14`
4) The first dialog thread now runs Create() and reads deviceFilter.Get(). That field may now hold the second filter (or even be null if the second thread cleared it early). `dshow-dialogbox.cpp:33`
5) The first thread can now call GetPages on a filter whose lifetime is not stable because the second thread may clear deviceFilter and release the COM object concurrently. `dshow-dialogbox.cpp:37` and `dshow-dialogbox.cpp:48`

### How Has This Been Tested?
Manually, Windows only

### Types of changes
- Bug fix (non-breaking change which fixes an issue)